### PR TITLE
Duplicate equation in example

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -358,9 +358,7 @@ ggplot(data = mpg) +
   geom_smooth(mapping = aes(x = displ, y = hwy, group = drv))
     
 ggplot(data = mpg) +
-  geom_smooth(
-    mapping = aes(x = displ, y = hwy, group = drv)
-  )
+  geom_smooth(mapping = aes(x = displ, y = hwy, linetype = drv))
 ```
 
 To display multiple geoms in the same plot, add multiple geom functions to `ggplot()`:


### PR DESCRIPTION
Equation two and three were exactly the same, only with different formatting. Maybe the third equation is meant to be with linetype?